### PR TITLE
Beaufort Scale bugfix, alarm delay implemented

### DIFF
--- a/src/virtualChannels/delayedAlertSystem.ts
+++ b/src/virtualChannels/delayedAlertSystem.ts
@@ -1,0 +1,46 @@
+import {Channel} from "../channel";
+import {PairingIds} from "../pairingIds";
+
+export class DelayedAlertSystem {
+    private delayedAlert : NodeJS.Timeout | null = null;
+    private delayedDeAlert: NodeJS.Timeout | null = null;
+
+    private activationDelay : number | undefined;
+    private deactivationDelay : number | undefined;
+
+
+
+    public alertDelayed(channel :Channel, alarm :PairingIds){
+        if(this.delayedDeAlert){
+            clearTimeout(this.delayedDeAlert);
+            this.delayedDeAlert = null;
+        }
+        if(!this.delayedAlert){
+            setTimeout(() => this.alert(channel,alarm),this.activationDelay ?? 0);
+        }
+    }
+    public dealertDelayed(channel :Channel, alarm :PairingIds){
+        if(this.delayedAlert){
+            clearTimeout(this.delayedAlert);
+            this.delayedAlert = null;
+        }
+        if(!this.delayedDeAlert){
+            setTimeout(() => this.dealert(channel,alarm),this.deactivationDelay ?? 0);
+        }
+    }
+
+    public setActivationDelay(delayInMinutes:number){
+        this.activationDelay = delayInMinutes * 60_000; // Minutes to Milliseconds
+    }
+
+    public setDeactivatoinDelay(delayInMinutes:number){
+        this.deactivationDelay = delayInMinutes * 60_000;
+    }
+
+    private alert( channel :Channel, alarm :PairingIds){
+        channel.setDatapoint(alarm,"1");
+    }
+    private dealert( channel :Channel, alarm :PairingIds){
+        channel.setDatapoint(alarm,"0");
+    }
+}

--- a/src/virtualChannels/weatherWindSensorChannel.ts
+++ b/src/virtualChannels/weatherWindSensorChannel.ts
@@ -43,8 +43,7 @@ export class WeatherWindSensorChannel extends Mixin(Channel, (EventEmitter as { 
 
     setWindSpeed(windSpeed: number): void {
         this.setDatapoint(PairingIds.AL_WIND_SPEED, <string><unknown>windSpeed);
-
-        const alarmLevel = binaryIndexOf(windAlarmLevels, windSpeed);
+        const alarmLevel = this.getBeaufortLevel(windSpeed);
         console.log("wind alarm level: %s", alarmLevel);
         this.setDatapoint(PairingIds.AL_WIND_FORCE, <string><unknown>alarmLevel);
 
@@ -65,11 +64,20 @@ export class WeatherWindSensorChannel extends Mixin(Channel, (EventEmitter as { 
         switch (id) {
             case ParameterIds.PID_WIND_FORCE:
                 this.windAlarmLevel = <number>parseInt(value);
-                console.log("Parameter wind Alarm activation level changed %s", this.windAlarmLevel);
+                console.log("Parameter wind alarm activation level changed %s", this.windAlarmLevel);
                 break;
 
             default:
                 console.log("unexpected Parameter id: %s value: %s", id, value);
         }
+    }
+
+    private getBeaufortLevel(windSpeed:number) {
+        for(let i = 0; i < windAlarmLevels.length; i++) {
+            if(windSpeed < windAlarmLevels[i]) {
+                return i-1;
+            }
+        }
+        return 12; // If the wind speed is beyond the highest value in the array
     }
 }

--- a/src/virtualChannels/weatherWindSensorChannel.ts
+++ b/src/virtualChannels/weatherWindSensorChannel.ts
@@ -65,7 +65,7 @@ export class WeatherWindSensorChannel extends Mixin(Channel, (EventEmitter as { 
         switch (id) {
             case ParameterIds.PID_WIND_FORCE:
                 this.windAlarmLevel = <number>parseInt(value);
-                console.log("Parameter temperature alertActivationLevel changed %s", this.windAlarmLevel);
+                console.log("Parameter wind Alarm activation level changed %s", this.windAlarmLevel);
                 break;
 
             default:


### PR DESCRIPTION
When using this package, I encountered these issues:

- Logging in weatherWindSensorChannel was ...."rain alert".. changed to wind alert
- By using binary search with windspeed in the windAlertLevel array, the function returned a to high beaufort value.
- Parameters (de)alert activation level were not implemented. I created a delayed alarm system, by now only for the wind channel, but it can be used by the other 3 weather station channels, if wished.

Please let me know if i should implement the delayedAlertSystem for the other channels.
Maybe we can create something like weatherStationChannel which extends from Channel because AFAIK there is only wind alert, rain alert, brightness alert and temperature alert.