### PR TITLE
fix: websocket open event not being emitted by FreeAtHomeApi

### DIFF
--- a/src/freeAtHomeApi.ts
+++ b/src/freeAtHomeApi.ts
@@ -86,6 +86,8 @@ export class FreeAtHomeApi extends (EventEmitter as { new(): Emitter }) {
         this.websocket = websocket;
 
         this.websocket.on('message', this.parseWebsocketData.bind(this));
+        this.websocket.on('open', () => this.emit('open', this));
+        this.websocket.on('close', (code: number, reason: string) => this.emit('close', code, reason));
     }
 
     disconnect() {


### PR DESCRIPTION
The FreeAtHomeApi constructor was only listening for 'message' events from the websocket, but not forwarding 'open' and 'close' events. This caused the FreeAtHome instance's open event to never be triggered even though the websocket connection was successfully established.

Added missing event listeners in FreeAtHomeApi constructor to:
- Forward websocket 'open' events to emit('open', this)
- Forward websocket 'close' events to emit('close', code, reason)

This ensures the complete event chain works:
AutoReconnectWebSocket -> FreeAtHomeApi -> FreeAtHome

🤖 Generated with [Claude Code](https://claude.ai/code)